### PR TITLE
fix: new dir arch

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -178,11 +178,45 @@ json_get_string() {
   json_get_value "$key" "$json" | sed 's/^[[:blank:]]*"\(.*\)"[[:blank:]]*$/\1/'
 }
 
+new_dir_arch() {
+  local version="$1"
+	local major_cutoff=0
+	local minor_cutoff=6
+	local patch_cutoff=6
+
+	if [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+		local major="${BASH_REMATCH[1]}"
+		local minor="${BASH_REMATCH[2]}"
+		local patch="${BASH_REMATCH[3]}"
+
+		local major_gt="$([[ $major -gt $major_cutoff ]] && echo 0 || echo 1)"
+		local minor_gt="$([[ $minor -gt $minor_cutoff ]] && echo 0 || echo 1)"
+		local patch_gt="$([[ $patch -gt $patch_cutoff ]] && echo 0 || echo 1)"
+
+		local major_eq="$([[ $major -eq $major_cutoff ]] && echo 0 || echo 1)"
+		local minor_eq="$([[ $minor -eq $minor_cutoff ]] && echo 0 || echo 1)"
+		local patch_eq="$([[ $patch -eq $patch_cutoff ]] && echo 0 || echo 1)"
+
+		local major_match="$([[ $major_gt -eq 0 ]] && echo 0 || echo 1)"
+		local minor_match="$(([[ $major_eq -eq 0 ]] && [[ $minor_gt -eq 0 ]]) && echo 0 || echo 1)"
+		local patch_match="$(([[ $major_eq -eq 0 ]] && [[ $minor_eq -eq 0 ]] && [[ $patch_gt -eq 0 ]]) && echo 0 || echo 1)"
+
+		local new_dir_arch="$(([[ $major_match -eq 0 ]] || [[ $minor_match -eq 0 ]] || [[ $patch_match -eq 0 ]]) && echo 0 || echo 1)"
+
+    echo "$new_dir_arch"
+  else
+    fail "Cannot parse version: $version"
+	fi
+}
+
 platform() {
+  local version="$1"
+  local new_dir_arch=$(new_dir_arch "$version")
+
   if [[ "$OSTYPE" == "linux"* ]]; then
-    echo "linux"
+    if [[ $new_dir_arch -eq 0 ]]; then echo "Linux"; else echo "platform-linux"; fi
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "darwin"
+    if [[ $new_dir_arch -eq 0 ]]; then echo "macOS"; else echo "platform-darwin"; fi
   else
     fail "Unknown platform: $OSTYPE"
   fi
@@ -259,13 +293,13 @@ extract_package() {
 install_package_esy() {
   local package_dir="$1"
   local install_dir="$2"
-  local platform=$(platform)
+  local platform=$(platform "$version")
 
   [ -e "$install_dir/bin" ] || mkdir "$install_dir/bin"
 
   cp "$package_dir/package/package.json" "$install_dir"
-  cp "$package_dir/package/platform-$platform/_build/default/bin/esyInstallRelease.js" "$install_dir/bin"
-  cp -r "$package_dir/package/platform-$platform/_build" "$install_dir"
+  cp "$package_dir/package/$platform/_build/default/bin/esyInstallRelease.js" "$install_dir/bin"
+  cp -r "$package_dir/package/$platform/_build" "$install_dir"
 
   chmod 0555 "$install_dir/_build/default/esy-build-package/bin/esyBuildPackageCommand.exe"
   chmod 0555 "$install_dir/_build/default/esy-build-package/bin/esyRewritePrefixCommand.exe"
@@ -294,12 +328,12 @@ install_package_esy_opam() {
 install_package_esy_solve_cudf() {
   local package_dir="$1"
   local install_dir="$2"
-  local platform=$(platform)
+  local platform=$(platform "$version")
 
   [ -e "$install_dir/node_modules/esy-solve-cudf" ] || mkdir -p "$install_dir/node_modules/esy-solve-cudf"
 
   cp "$package_dir/package/package.json" "$install_dir/node_modules/esy-solve-cudf"
-  cp "$package_dir/package/platform-$platform/esySolveCudfCommand.exe" "$install_dir/node_modules/esy-solve-cudf"
+  cp "$package_dir/package/$platform/esySolveCudfCommand.exe" "$install_dir/node_modules/esy-solve-cudf"
 }
 
 install_package_dependencies() {


### PR DESCRIPTION
This PR fixes a directory change in esy's npm release that first occured in 0.6.7.

Since 0.6.7, `asdf install esy 0.6.7` failed with the ff:
```
Downloading esy, version 0.6.7
Extracting esy
Installing esy
cp: cannot stat '/tmp/asdf_esy_Yl0dPG/esy-0.6.7/package/platform-linux/_build/default/bin/esyInstallRelease.js': No such file or directory
```

This was the directory structure in (and prior to) 0.6.6:
![esy02](https://user-images.githubusercontent.com/4323447/97961392-31cef200-1dee-11eb-87f1-c3b9152e0179.png)

This is how 0.6.7 (and assuming future versions) looks:
![esy01](https://user-images.githubusercontent.com/4323447/97961468-5925bf00-1dee-11eb-94ec-65cede4eab8b.png)

I just used a naive semver comparison function. If you'd prefer a different approach (I liberally used ternaries), please suggest and I will happily adjust. No issues if you'd like to edit the change yourselves as well.

If I missed something, please let me know.

Here's a unit test to play around with:
```
#!/usr/bin/env bash
set -e

new_dir_arch() {
  local version="$1"
	local major_cutoff=0
	local minor_cutoff=6
	local patch_cutoff=6

	if [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
		local major="${BASH_REMATCH[1]}"
		local minor="${BASH_REMATCH[2]}"
		local patch="${BASH_REMATCH[3]}"

		local major_gt="$([[ $major -gt $major_cutoff ]] && echo 0 || echo 1)"
		local minor_gt="$([[ $minor -gt $minor_cutoff ]] && echo 0 || echo 1)"
		local patch_gt="$([[ $patch -gt $patch_cutoff ]] && echo 0 || echo 1)"

		local major_eq="$([[ $major -eq $major_cutoff ]] && echo 0 || echo 1)"
		local minor_eq="$([[ $minor -eq $minor_cutoff ]] && echo 0 || echo 1)"
		local patch_eq="$([[ $patch -eq $patch_cutoff ]] && echo 0 || echo 1)"

		local major_match="$([[ $major_gt -eq 0 ]] && echo 0 || echo 1)"
		local minor_match="$(([[ $major_eq -eq 0 ]] && [[ $minor_gt -eq 0 ]]) && echo 0 || echo 1)"
		local patch_match="$(([[ $major_eq -eq 0 ]] && [[ $minor_eq -eq 0 ]] && [[ $patch_gt -eq 0 ]]) && echo 0 || echo 1)"

		local new_dir_arch="$(([[ $major_match -eq 0 ]] || [[ $minor_match -eq 0 ]] || [[ $patch_match -eq 0 ]]) && echo 0 || echo 1)"

    echo "$new_dir_arch"
  else
    fail "Cannot parse version: $version"
	fi
}

platform() {
  local version="$1"
  local new_dir_arch=$(new_dir_arch "$version")

  if [[ "$OSTYPE" == "linux"* ]]; then
    if [[ $new_dir_arch -eq 0 ]]; then echo "Linux"; else echo "platform-linux"; fi
  elif [[ "$OSTYPE" == "darwin"* ]]; then
    if [[ $new_dir_arch -eq 0 ]]; then echo "macOS"; else echo "platform-darwin"; fi
  else
    fail "Unknown platform: $OSTYPE"
  fi
}

esy_install() {
  local version="$1"
  local platform=$(platform "$version")

  echo "$version platform: $platform"
}

esy_install "0.5.5"
esy_install "0.5.10"
esy_install "0.6.5"
esy_install "0.6.6"
esy_install "0.6.7"
esy_install "0.6.8"
esy_install "0.7.4"
esy_install "1.0.0"
esy_install "1.1.1"
esy_install "1.6.7"
esy_install "1.6.6"
```



